### PR TITLE
feat: .otf file conversion support

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import Fontmin from 'fontmin';
-import fs from 'fs';
+import rename from 'gulp-rename';
 import path from 'path';
 
 export function convertFont(inputPath) {
@@ -14,24 +14,42 @@ export function convertFont(inputPath) {
   const outputPath = path.dirname(inputPath);
   const fileName = path.basename(inputPath, ext);
 
-  const fontmin = new Fontmin()
-    .src(inputPath)
-    .use(Fontmin.ttf2eot())
-    .use(Fontmin.ttf2svg())
-    .use(Fontmin.ttf2woff2())
-    .dest(outputPath);
+  const convertFiles = (input, outputDirectory) => {
+    const fontmin = new Fontmin()
+      .src(input)
+      .use(rename((path) => {
+        path.basename = fileName
+      }))
+      .use(Fontmin.ttf2eot())
+      .use(Fontmin.ttf2svg())
+      .use(Fontmin.ttf2woff2())
+      .dest(outputDirectory);
 
-  fontmin.run((err, files) => {
-    if (err) {
-      console.error('Error during conversion:', err);
-      return;
-    }
-
-    files.forEach((file) => {
-      const outputFilePath = path.join(outputPath, `${fileName}${path.extname(file.path)}`);
-      fs.writeFileSync(outputFilePath, file.contents);
+    fontmin.run((err, files) => {
+      if (err) {
+        console.error('Error during conversion:', err);
+        return;
+      }
+      console.log('Fonts converted successfully!');
     });
+  }
 
-    console.log('Fonts converted successfully!');
-  });
+  if (ext === '.otf') {
+    const otfFontmin = new Fontmin()
+      .src(inputPath)
+      .use(Fontmin.otf2ttf());
+
+    otfFontmin.run((err, files) => {
+      if (err) {
+        console.error('Error during .otf to .ttf conversion:', err);
+        return;
+      }
+      files.forEach(file => {
+        convertFiles(file.contents, outputPath);
+      });
+    });
+  } else {
+    convertFiles(inputPath, outputPath);
+  }
+
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,8 +14,12 @@
                 "figlet": "^1.7.0",
                 "fontmin": "^1.0.1",
                 "gradient-string": "^2.0.2",
+                "gulp-rename": "^2.0.0",
                 "inquirer": "^9.2.11",
                 "nanospinner": "^1.1.0"
+            },
+            "bin": {
+                "fontpls": "cli.js"
             },
             "devDependencies": {
                 "mocha": "^10.2.0"
@@ -1762,6 +1766,14 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/gulp-rename": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-2.0.0.tgz",
+            "integrity": "sha512-97Vba4KBzbYmR5VBs9mWmK+HwIf5mj+/zioxfZhOKeXtx5ZjBk57KFlePf5nxq9QsTtFl0ejnHE3zTC9MHXqyQ==",
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/hard-rejection": {
@@ -5506,6 +5518,11 @@
                     }
                 }
             }
+        },
+        "gulp-rename": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-2.0.0.tgz",
+            "integrity": "sha512-97Vba4KBzbYmR5VBs9mWmK+HwIf5mj+/zioxfZhOKeXtx5ZjBk57KFlePf5nxq9QsTtFl0ejnHE3zTC9MHXqyQ=="
         },
         "hard-rejection": {
             "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "figlet": "^1.7.0",
         "fontmin": "^1.0.1",
         "gradient-string": "^2.0.2",
+        "gulp-rename": "^2.0.0",
         "inquirer": "^9.2.11",
         "nanospinner": "^1.1.0"
     }


### PR DESCRIPTION
- [x] if an `.otf` file is provided to the package it converts it to a `.ttf` file first and then converts the `.ttf` to `.eot`, `.svg`, and `.woff2`

note: the `.ttf` file is also written to the system, do we care about that?